### PR TITLE
Implement enable/disable commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enhanced extension entry point with comprehensive state management
 - Commands now have functional implementation instead of placeholder notifications
 - Improved status bar with interactive toggle and visual state indicators
+- Simplified implementation by removing redundant language configuration management
+- Refactored StateNotification into separate module (`src/stateNotification.ts`) for better code organization
 - Updated documentation to reflect new functionality
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the SongTxt extension will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Enable/Disable functionality**: Commands now provide full control over SongTxt syntax highlighting
+- **Status bar integration**: Visual indicator showing current state with one-click toggle
+- **Real-time document control**: Immediately applies changes to currently open files
+- **Persistent state management**: Remembers enabled/disabled preference across VS Code sessions
+- **Event-driven state enforcement**: Maintains correct language mode when switching tabs or opening files
+
+### Changed
+
+- Enhanced extension entry point with comprehensive state management
+- Commands now have functional implementation instead of placeholder notifications
+- Improved status bar with interactive toggle and visual state indicators
+- Updated documentation to reflect new functionality
+
+### Fixed
+
+- Commands now properly enable/disable syntax highlighting for both new and existing files
+- Resolved proxy extensibility issues when modifying VS Code configuration
+
 ## [0.1.10] - 2025-08-18
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,10 +37,10 @@ npm run vscode:prepublish  # Prepare extension for publishing (compiles code)
 **Extension Entry Point** (`src/extension.ts`)
 - Main activation/deactivation logic
 - Registers two functional commands: `extension.enableSongtxt` and `extension.disableSongtxt`
-- Creates status bar notification system via `StateNotification` class
+- Creates status bar notification system via `StateNotification` class (in separate file)
 - Implements dynamic enable/disable of syntax highlighting for .txt/.tab files
 - Uses VS Code's `setTextDocumentLanguage` API to control language modes
-- Manages file associations and language configuration programmatically
+- Manages file associations programmatically (language configuration handled statically)
 - Event-driven system that maintains state across tab switches and file operations
 
 **Language Definition** (`package.json` contributes section)
@@ -101,12 +101,13 @@ This is a standard VS Code extension with TypeScript source. The extension combi
 - **File Association Control**: Dynamically modifies VS Code's `files.associations` setting to control which files use the `songtxt` language
 - **Document Language Control**: Uses `vscode.languages.setTextDocumentLanguage()` to immediately change language modes of open documents
 - **Event Listeners**: Monitors document opening, tab switching, and editor visibility changes to maintain consistent state
-- **Language Configuration**: Programmatically registers/unregisters language features (brackets, auto-closing pairs)
+- **Modular Design**: StateNotification class separated into `src/stateNotification.ts` for better code organization
 
 **Enable/Disable Mechanism:**
 1. **Enable**: Associates .txt/.tab files with `songtxt` language, applies syntax highlighting to open documents
 2. **Disable**: Removes file associations, converts open documents to `plaintext` mode (removes highlighting)
 3. **State Persistence**: Remembers user preference and applies it on extension activation
+4. **Language Features**: Bracket matching and auto-closing handled by static `language-configuration.json`
 
 ### Build Process
 - TypeScript compiles to `out/` directory

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,9 +36,12 @@ npm run vscode:prepublish  # Prepare extension for publishing (compiles code)
 
 **Extension Entry Point** (`src/extension.ts`)
 - Main activation/deactivation logic
-- Registers two placeholder commands: `extension.enableSongtxt` and `extension.disableSongtxt`
+- Registers two functional commands: `extension.enableSongtxt` and `extension.disableSongtxt`
 - Creates status bar notification system via `StateNotification` class
-- Commands currently only show notifications (placeholder functionality)
+- Implements dynamic enable/disable of syntax highlighting for .txt/.tab files
+- Uses VS Code's `setTextDocumentLanguage` API to control language modes
+- Manages file associations and language configuration programmatically
+- Event-driven system that maintains state across tab switches and file operations
 
 **Language Definition** (`package.json` contributes section)
 - Defines `songtxt` language for `.txt` and `.tab` files
@@ -91,7 +94,19 @@ The chord regex is complex and designed to avoid false positives in lyrics. It u
 - Allows slash chords (C/G)
 
 ### Extension Structure
-This is a standard VS Code extension with TypeScript source. The extension is minimal - most functionality comes from the TextMate grammar and language configuration rather than programmatic features.
+This is a standard VS Code extension with TypeScript source. The extension combines TextMate grammar/language configuration with programmatic features for dynamic control:
+
+**Key Implementation Details:**
+- **State Management**: Uses `context.globalState` to persist enabled/disabled state across sessions
+- **File Association Control**: Dynamically modifies VS Code's `files.associations` setting to control which files use the `songtxt` language
+- **Document Language Control**: Uses `vscode.languages.setTextDocumentLanguage()` to immediately change language modes of open documents
+- **Event Listeners**: Monitors document opening, tab switching, and editor visibility changes to maintain consistent state
+- **Language Configuration**: Programmatically registers/unregisters language features (brackets, auto-closing pairs)
+
+**Enable/Disable Mechanism:**
+1. **Enable**: Associates .txt/.tab files with `songtxt` language, applies syntax highlighting to open documents
+2. **Disable**: Removes file associations, converts open documents to `plaintext` mode (removes highlighting)
+3. **State Persistence**: Remembers user preference and applies it on extension activation
 
 ### Build Process
 - TypeScript compiles to `out/` directory

--- a/README.md
+++ b/README.md
@@ -8,15 +8,26 @@ Install the extension from the [Visual Studio Marketplace](https://marketplace.v
 
 ## Features
 
-See the list of features and documentation at the [SongTxt Wiki](https://github.com/gusper/SongTxt-vscode/wiki).
+- **Syntax Highlighting**: Automatic highlighting for chords, song sections, and guitar tablature in `.txt` and `.tab` files
+- **Toggle Control**: Enable or disable SongTxt syntax highlighting on demand
+- **Status Bar Integration**: Visual indicator showing current state with one-click toggle
+- **Smart File Detection**: Automatically applies to Ultimate Guitar formatted text files
+- **Grammar Testing**: Comprehensive regex testing to ensure accurate chord recognition
+
+See the full list of features and documentation at the [SongTxt Wiki](https://github.com/gusper/SongTxt-vscode/wiki).
+
+## Commands
+
+SongTxt provides two commands accessible via the Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`):
+
+- **Enable SongTxt**: Activates syntax highlighting for `.txt` and `.tab` files
+- **Disable SongTxt**: Deactivates syntax highlighting (files appear as plain text)
+
+You can also toggle between enabled/disabled states by clicking the SongTxt status bar item.
 
 ## Screenshot
 
 ![Screenshot](https://i.imgur.com/gFU6lS8.png)
-
-## Known Issues
-
-- The two commands the extension adds currently do nothing other than pop up a notification when executed. More to come soon there as well.
 
 ## Release Notes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "typescript-eslint": "^8.40.0"
             },
             "engines": {
-                "vscode": "^1.102.0"
+                "vscode": "^1.103.0"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
         "commands": [
             {
                 "command": "extension.enableSongtxt",
-                "title": "Enable SongTxt"
+                "title": "Enable SongTxt",
+                "category": "SongTxt"
             },
             {
                 "command": "extension.disableSongtxt",
-                "title": "Disable SongTxt"
+                "title": "Disable SongTxt",
+                "category": "SongTxt"
             }
         ],
         "languages": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,12 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 
+// Global variables to store language configuration disposable and document state
+let languageConfigDisposable: vscode.Disposable | undefined;
+const originalLanguages = new Map<string, string>();
+let isExtensionEnabled = true;
+let documentListeners: vscode.Disposable[] = [];
+
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
@@ -10,14 +16,32 @@ export function activate(context: vscode.ExtensionContext) {
     // This line of code will only be executed once when your extension is activated
     console.log('SongTxt extension is now active.');
 
-    // create a new word counter
+    // Check current state from storage
+    isExtensionEnabled = context.globalState.get('songtxt.enabled', true);
+
+    // create state notification manager
     const stateNotification = new StateNotification();
 
-    const enableCommand = vscode.commands.registerCommand('extension.enableSongtxt', () => {
-        stateNotification.enabled();
+    // Set up document event listeners
+    setupDocumentEventListeners(context);
+
+    // Apply current state on activation
+    if (isExtensionEnabled) {
+        enableSongTxtFeatures(context, stateNotification);
+    } else {
+        disableSongTxtFeatures(context, stateNotification);
+    }
+
+    const enableCommand = vscode.commands.registerCommand('extension.enableSongtxt', async () => {
+        isExtensionEnabled = true;
+        await enableSongTxtFeatures(context, stateNotification);
+        await context.globalState.update('songtxt.enabled', true);
     });
-    const disableCommand = vscode.commands.registerCommand('extension.disableSongtxt', () => {
-        stateNotification.disabled();
+    
+    const disableCommand = vscode.commands.registerCommand('extension.disableSongtxt', async () => {
+        isExtensionEnabled = false;
+        await disableSongTxtFeatures(context, stateNotification);
+        await context.globalState.update('songtxt.enabled', false);
     });
     
     // Add to a list of disposables which are disposed when this extension is deactivated.
@@ -26,20 +50,223 @@ export function activate(context: vscode.ExtensionContext) {
     context.subscriptions.push(disableCommand);
 }
 
+async function enableSongTxtFeatures(context: vscode.ExtensionContext, stateNotification: StateNotification) {
+    try {
+        // Enable file associations for new files
+        await enableLanguageAssociations();
+        
+        // Enable language configuration
+        enableLanguageConfiguration();
+        
+        // Store disposable for cleanup
+        if (languageConfigDisposable) {
+            context.subscriptions.push(languageConfigDisposable);
+        }
+        
+        // Re-enable syntax highlighting for currently open documents
+        await enableSyntaxForOpenDocuments();
+        
+        // Update UI
+        stateNotification.updateState(true);
+        
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to enable SongTxt: ${error}`);
+    }
+}
+
+async function disableSongTxtFeatures(context: vscode.ExtensionContext, stateNotification: StateNotification) {
+    try {
+        // Disable file associations for new files
+        await disableLanguageAssociations();
+        
+        // Disable language configuration
+        disableLanguageConfiguration();
+        
+        // Disable syntax highlighting for currently open documents
+        await disableSyntaxForOpenDocuments();
+        
+        // Update UI
+        stateNotification.updateState(false);
+        
+    } catch (error) {
+        vscode.window.showErrorMessage(`Failed to disable SongTxt: ${error}`);
+    }
+}
+
+async function enableLanguageAssociations(): Promise<void> {
+    const fileConfiguration = vscode.workspace.getConfiguration('files');
+    const currentAssociations = fileConfiguration.get('associations') as Record<string, string> || {};
+    
+    // Create a new object to avoid proxy issues
+    const newAssociations = { ...currentAssociations };
+    newAssociations['*.txt'] = 'songtxt';
+    newAssociations['*.tab'] = 'songtxt';
+    
+    await fileConfiguration.update('associations', newAssociations, vscode.ConfigurationTarget.Global);
+}
+
+async function disableLanguageAssociations(): Promise<void> {
+    const fileConfiguration = vscode.workspace.getConfiguration('files');
+    const currentAssociations = fileConfiguration.get('associations') as Record<string, string> || {};
+    
+    // Create a new object to avoid proxy issues
+    const newAssociations = { ...currentAssociations };
+    
+    // Only remove if they're set to songtxt to avoid overriding user's custom settings
+    if (newAssociations['*.txt'] === 'songtxt') {
+        delete newAssociations['*.txt'];
+    }
+    if (newAssociations['*.tab'] === 'songtxt') {
+        delete newAssociations['*.tab'];
+    }
+    
+    await fileConfiguration.update('associations', newAssociations, vscode.ConfigurationTarget.Global);
+}
+
+function enableLanguageConfiguration(): void {
+    const languageConfig: vscode.LanguageConfiguration = {
+        brackets: [
+            ['{', '}'],
+            ['[', ']'],
+            ['(', ')'],
+            ['<', '>']
+        ],
+        autoClosingPairs: [
+            { open: '{', close: '}' },
+            { open: '[', close: ']' },
+            { open: '(', close: ')' }
+        ]
+    };
+    
+    languageConfigDisposable = vscode.languages.setLanguageConfiguration('songtxt', languageConfig);
+}
+
+function disableLanguageConfiguration(): void {
+    if (languageConfigDisposable) {
+        languageConfigDisposable.dispose();
+        languageConfigDisposable = undefined;
+    }
+}
+
+async function disableSyntaxForOpenDocuments(): Promise<void> {
+    const documents = vscode.workspace.textDocuments;
+    
+    for (const doc of documents) {
+        if (doc.languageId === 'songtxt') {
+            // Store original language for restoration
+            originalLanguages.set(doc.uri.toString(), doc.languageId);
+            
+            // Switch to plaintext to remove syntax highlighting
+            await vscode.languages.setTextDocumentLanguage(doc, 'plaintext');
+        }
+    }
+}
+
+async function enableSyntaxForOpenDocuments(): Promise<void> {
+    const documents = vscode.workspace.textDocuments;
+    
+    for (const doc of documents) {
+        const originalLang = originalLanguages.get(doc.uri.toString());
+        
+        if (originalLang === 'songtxt' && doc.languageId === 'plaintext') {
+            // Restore original language
+            await vscode.languages.setTextDocumentLanguage(doc, 'songtxt');
+        }
+        
+        // Also check for files that should be songtxt based on extension
+        if (!originalLang && 
+            (doc.fileName.endsWith('.txt') || doc.fileName.endsWith('.tab')) &&
+            doc.languageId === 'plaintext') {
+            // These files should be songtxt when enabled
+            await vscode.languages.setTextDocumentLanguage(doc, 'songtxt');
+        }
+    }
+    
+    // Clear the original languages map after restoration
+    originalLanguages.clear();
+}
+
+function setupDocumentEventListeners(context: vscode.ExtensionContext): void {
+    // Clear any existing listeners
+    documentListeners.forEach(listener => listener.dispose());
+    documentListeners = [];
+
+    // Listen for when documents are opened
+    const onDidOpenListener = vscode.workspace.onDidOpenTextDocument(async (document) => {
+        await handleDocumentStateChange(document);
+    });
+
+    // Listen for when the active editor changes (tab switching)
+    const onDidChangeActiveEditorListener = vscode.window.onDidChangeActiveTextEditor(async (editor) => {
+        if (editor?.document) {
+            await handleDocumentStateChange(editor.document);
+        }
+    });
+
+    // Listen for when visible editors change
+    const onDidChangeVisibleEditorsListener = vscode.window.onDidChangeVisibleTextEditors(async (editors) => {
+        for (const editor of editors) {
+            if (editor.document) {
+                await handleDocumentStateChange(editor.document);
+            }
+        }
+    });
+
+    documentListeners = [onDidOpenListener, onDidChangeActiveEditorListener, onDidChangeVisibleEditorsListener];
+    
+    // Add listeners to context for cleanup
+    context.subscriptions.push(...documentListeners);
+}
+
+async function handleDocumentStateChange(document: vscode.TextDocument): Promise<void> {
+    // Only handle txt and tab files
+    if (!document.fileName.endsWith('.txt') && !document.fileName.endsWith('.tab')) {
+        return;
+    }
+
+    if (!isExtensionEnabled) {
+        // Extension is disabled - ensure document is in plaintext mode
+        if (document.languageId === 'songtxt') {
+            await vscode.languages.setTextDocumentLanguage(document, 'plaintext');
+        }
+    } else {
+        // Extension is enabled - ensure document is in songtxt mode
+        if (document.languageId === 'plaintext') {
+            await vscode.languages.setTextDocumentLanguage(document, 'songtxt');
+        }
+    }
+}
+
 // this method is called when your extension is deactivated
 export function deactivate() {
+    // Clean up listeners
+    documentListeners.forEach(listener => listener.dispose());
+    documentListeners = [];
 }
 
 class StateNotification {
     
     private _statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    private _isEnabled: boolean = true;
+    
+    public updateState(enabled: boolean) {
+        this._isEnabled = enabled;
+        
+        if (enabled) {
+            this.enabled();
+        } else {
+            this.disabled();
+        }
+    }
     
     public enabled() {
         // Show notification
         vscode.window.showInformationMessage('SongTxt mode is now enabled');
         
         // Update the status bar
-        this._statusBarItem.text = 'SongTxt';
+        this._statusBarItem.text = '$(music) SongTxt: Enabled';
+        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is active. Click to disable.';
+        this._statusBarItem.command = 'extension.disableSongtxt';
         this._statusBarItem.show();
     }
 
@@ -48,7 +275,14 @@ class StateNotification {
         vscode.window.showInformationMessage('SongTxt mode is now disabled');
         
         // Update the status bar
-        this._statusBarItem.hide();
+        this._statusBarItem.text = '$(circle-slash) SongTxt: Disabled';
+        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is disabled. Click to enable.';
+        this._statusBarItem.command = 'extension.enableSongtxt';
+        this._statusBarItem.show();
+    }
+
+    public get isEnabled(): boolean {
+        return this._isEnabled;
     }
 
     dispose() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+import { StateNotification } from './stateNotification';
 
 // Global variables to store language configuration disposable and document state
 let languageConfigDisposable: vscode.Disposable | undefined;
@@ -244,48 +245,3 @@ export function deactivate() {
     documentListeners = [];
 }
 
-class StateNotification {
-    
-    private _statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
-    private _isEnabled: boolean = true;
-    
-    public updateState(enabled: boolean) {
-        this._isEnabled = enabled;
-        
-        if (enabled) {
-            this.enabled();
-        } else {
-            this.disabled();
-        }
-    }
-    
-    public enabled() {
-        // Show notification
-        vscode.window.showInformationMessage('SongTxt mode is now enabled');
-        
-        // Update the status bar
-        this._statusBarItem.text = '$(music) SongTxt: Enabled';
-        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is active. Click to disable.';
-        this._statusBarItem.command = 'extension.disableSongtxt';
-        this._statusBarItem.show();
-    }
-
-    public disabled() {
-        // Show notification
-        vscode.window.showInformationMessage('SongTxt mode is now disabled');
-        
-        // Update the status bar
-        this._statusBarItem.text = '$(circle-slash) SongTxt: Disabled';
-        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is disabled. Click to enable.';
-        this._statusBarItem.command = 'extension.enableSongtxt';
-        this._statusBarItem.show();
-    }
-
-    public get isEnabled(): boolean {
-        return this._isEnabled;
-    }
-
-    dispose() {
-        this._statusBarItem.dispose();
-    }
-}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,7 +112,6 @@ async function disableLanguageAssociations(): Promise<void> {
     await fileConfiguration.update('associations', newAssociations, vscode.ConfigurationTarget.Global);
 }
 
-
 async function disableSyntaxForOpenDocuments(): Promise<void> {
     const documents = vscode.workspace.textDocuments;
     

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,7 @@
 import * as vscode from 'vscode';
 import { StateNotification } from './stateNotification';
 
-// Global variables to store language configuration disposable and document state
-let languageConfigDisposable: vscode.Disposable | undefined;
+// Global variables to store document state
 const originalLanguages = new Map<string, string>();
 let isExtensionEnabled = true;
 let documentListeners: vscode.Disposable[] = [];
@@ -56,14 +55,6 @@ async function enableSongTxtFeatures(context: vscode.ExtensionContext, stateNoti
         // Enable file associations for new files
         await enableLanguageAssociations();
         
-        // Enable language configuration
-        enableLanguageConfiguration();
-        
-        // Store disposable for cleanup
-        if (languageConfigDisposable) {
-            context.subscriptions.push(languageConfigDisposable);
-        }
-        
         // Re-enable syntax highlighting for currently open documents
         await enableSyntaxForOpenDocuments();
         
@@ -79,9 +70,6 @@ async function disableSongTxtFeatures(context: vscode.ExtensionContext, stateNot
     try {
         // Disable file associations for new files
         await disableLanguageAssociations();
-        
-        // Disable language configuration
-        disableLanguageConfiguration();
         
         // Disable syntax highlighting for currently open documents
         await disableSyntaxForOpenDocuments();
@@ -124,30 +112,6 @@ async function disableLanguageAssociations(): Promise<void> {
     await fileConfiguration.update('associations', newAssociations, vscode.ConfigurationTarget.Global);
 }
 
-function enableLanguageConfiguration(): void {
-    const languageConfig: vscode.LanguageConfiguration = {
-        brackets: [
-            ['{', '}'],
-            ['[', ']'],
-            ['(', ')'],
-            ['<', '>']
-        ],
-        autoClosingPairs: [
-            { open: '{', close: '}' },
-            { open: '[', close: ']' },
-            { open: '(', close: ')' }
-        ]
-    };
-    
-    languageConfigDisposable = vscode.languages.setLanguageConfiguration('songtxt', languageConfig);
-}
-
-function disableLanguageConfiguration(): void {
-    if (languageConfigDisposable) {
-        languageConfigDisposable.dispose();
-        languageConfigDisposable = undefined;
-    }
-}
 
 async function disableSyntaxForOpenDocuments(): Promise<void> {
     const documents = vscode.workspace.textDocuments;

--- a/src/stateNotification.ts
+++ b/src/stateNotification.ts
@@ -1,0 +1,43 @@
+import * as vscode from 'vscode';
+
+export class StateNotification {
+    
+    private _statusBarItem: vscode.StatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
+    private _isEnabled: boolean = true;
+    
+    public updateState(enabled: boolean) {
+        this._isEnabled = enabled;
+        
+        if (enabled) {
+            this.enabled();
+        } else {
+            this.disabled();
+        }
+    }
+    
+    public enabled() {
+        vscode.window.showInformationMessage('SongTxt mode is now enabled');
+        
+        this._statusBarItem.text = '$(music) SongTxt: Enabled';
+        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is active. Click to disable.';
+        this._statusBarItem.command = 'extension.disableSongtxt';
+        this._statusBarItem.show();
+    }
+
+    public disabled() {
+        vscode.window.showInformationMessage('SongTxt mode is now disabled');
+        
+        this._statusBarItem.text = '$(circle-slash) SongTxt: Disabled';
+        this._statusBarItem.tooltip = 'SongTxt syntax highlighting is disabled. Click to enable.';
+        this._statusBarItem.command = 'extension.enableSongtxt';
+        this._statusBarItem.show();
+    }
+
+    public get isEnabled(): boolean {
+        return this._isEnabled;
+    }
+
+    dispose() {
+        this._statusBarItem.dispose();
+    }
+}


### PR DESCRIPTION
This pull request introduces major enhancements to the SongTxt VS Code extension, focusing on dynamic enable/disable functionality, improved state management, and a more interactive user experience. The extension now allows users to toggle syntax highlighting for `.txt` and `.tab` files, with persistent preferences and real-time updates across open documents and editor events. The codebase has been refactored for modularity and maintainability, and documentation has been updated to reflect these new capabilities.

Fixes #33.